### PR TITLE
delete auth details from redis when app is uninstalled or token is revoked

### DIFF
--- a/src/api/slack/slack.go
+++ b/src/api/slack/slack.go
@@ -391,6 +391,15 @@ func (s *slackHandler) eventListener() gin.HandlerFunc {
 			}
 		}
 
+		// if app is uninstalled or token is revoked
+		if req.Event.Type == model.EventTypeTokensRevoked || req.Event.Type == model.EventTypeAppUninstalled {
+			if err := s.controller.RemoveAuthDetails(context.Background(), req.TeamID); err != nil {
+				log.Err(err).Msg("RemoveAuthDetails failed")
+				restModel.ErrorResponse(c, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+
 		c.JSON(http.StatusOK, gin.H{"status": "event received"})
 	}
 }

--- a/src/api/slack/slack.go
+++ b/src/api/slack/slack.go
@@ -352,8 +352,6 @@ func (s *slackHandler) eventListener() gin.HandlerFunc {
 			return
 		}
 
-		log.Info().Interface("SlackEventCallback", req).Msg("event listener")
-
 		if req.Type == model.SlackCallbackEventURLVerification {
 			c.JSON(http.StatusOK, gin.H{"challenge": req.Challenge})
 			return

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -37,6 +37,7 @@ type Operations interface {
 	ShuffleSticker(ctx context.Context, teamID, userID, channelID, responseURL string, sticker model.StickerBlockMetadata) error
 
 	SaveAuthDetails(ctx context.Context, authDetails model.SlackAuthDetails) error
+	RemoveAuthDetails(ctx context.Context, teamID string) error
 }
 
 // Controller object to hold necessary reference to other dependencies

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -105,6 +105,11 @@ func (c *Controller) getSlackService(ctx context.Context, teamID string) (slack.
 		return slack.Provider{}, err
 	}
 
-	s := slack.New(c.logger, c.env, authDetails.AccessToken)
+	accessToken := authDetails.AccessToken
+	if authDetails.AuthedUser.AccessToken != "" {
+		accessToken = authDetails.AuthedUser.AccessToken
+	}
+
+	s := slack.New(c.logger, c.env, accessToken)
 	return *s, nil
 }

--- a/src/controller/slack.go
+++ b/src/controller/slack.go
@@ -76,7 +76,7 @@ func (c *Controller) ShowSearchResultModal(ctx context.Context, triggerID, chann
 	return nil
 }
 
-// SaveAuthDetails handles function to safe the authorization details to redis
+// SaveAuthDetails handles function to save the authorization details to redis
 func (c *Controller) SaveAuthDetails(ctx context.Context, authDetails model.SlackAuthDetails) error {
 	log := c.logger.With().Str(helper.LogStrKeyMethod, "SaveAuthDetails").Logger()
 
@@ -90,6 +90,18 @@ func (c *Controller) SaveAuthDetails(ctx context.Context, authDetails model.Slac
 	err = c.store.SetValue(ctx, authDetails.Team.ID, string(bytes), 0)
 	if err != nil {
 		log.Err(err).Msg("store.SetValue failed")
+		return err
+	}
+
+	return nil
+}
+
+// RemoveAuthDetails deletes the auth details from redis
+func (c *Controller) RemoveAuthDetails(ctx context.Context, teamID string) error {
+	log := c.logger.With().Str(helper.LogStrKeyMethod, "RemoveAuthDetails").Logger()
+
+	if err := c.store.DeleteValue(ctx, teamID); err != nil {
+		log.Err(err).Msg("store.DeleteValue failed")
 		return err
 	}
 

--- a/src/model/model.go
+++ b/src/model/model.go
@@ -40,6 +40,12 @@ const (
 	// EventTypeAppMention for when the bot is mentioned
 	EventTypeAppMention = "app_mention"
 
+	// EventTypeAppUninstalled for when the bot is uninstalled/removed from a workspace
+	EventTypeAppUninstalled = "app_uninstalled"
+
+	// EventTypeTokensRevoked for when the bot token is revoked
+	EventTypeTokensRevoked = "tokens_revoked"
+
 	// SlackCallbackEventURLVerification for verifying the url for event listener handler
 	// https://api.slack.com/events/url_verification
 	SlackCallbackEventURLVerification = "url_verification"


### PR DESCRIPTION
- delete auth details from redis when app is uninstalled or token is revoked 
- use authed user access token